### PR TITLE
chore(deps): Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build and test (Node ${{ matrix.node.name }})
     steps:
       - name: Check out the code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Set up Node.js environment
         uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # tag=v3.5.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@904260d7d935dff982205cbdb42025ce30b7a34f # tag=v2.1.24

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,7 +24,7 @@ jobs:
             github.com:443
 
       - name: Check out the source code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Review dependencies
         uses: actions/dependency-review-action@23d1ffffb6fa5401173051ec21eba8c35242733f # tag=v2

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.event_name == 'release' || github.event.inputs.npm == 'yes'
     steps:
       - name: Checkout source
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Set up Node.js environment
         uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # tag=v3.5.0
@@ -33,7 +33,7 @@ jobs:
       content: write
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # tag=v0.1.14

--- a/.github/workflows/sonarscan.yml
+++ b/.github/workflows/sonarscan.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the source code
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Merge remote-tracking branches 'origin/renovate/actions-checkout-3.x', 'origin/renovate/github-codeql-action-2.x', 'origin/renovate/actions-setup-node-3.x', and 'origin/renovate/actions-dependency-review-action-digest' into update-actions.

  * update actions/checkout action to v3.1.0 (https://github.com/sjinks/rollup-plugin-terser/pull/7)
  * update github/codeql-action action to v2.1.27 (https://github.com/sjinks/rollup-plugin-terser/pull/5)
  * update actions/setup-node action to v3.5.1 (https://github.com/sjinks/rollup-plugin-terser/pull/4)
  * update actions/dependency-review-action digest to fd675ce (https://github.com/sjinks/rollup-plugin-terser/pull/3)
